### PR TITLE
Bugfix for classification when an SV type is not present

### DIFF
--- a/savana/helper.py
+++ b/savana/helper.py
@@ -14,7 +14,7 @@ import sys
 from time import time
 from datetime import datetime
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 samflag_desc_to_number = {
 	"BAM_CMATCH": 0, # M

--- a/savana/train.py
+++ b/savana/train.py
@@ -53,8 +53,12 @@ def format_data(data_matrix):
 
 	# convert the SVTYPE to 0/1
 	data_matrix['SVTYPE'] = data_matrix['SVTYPE'].map({'BND':0,'INS':1})
-	# ONE-HOT ENCODING
+	# one-hot-encoding of BP_NOTATION
 	sv_type_one_hot = pd.get_dummies(data_matrix['BP_NOTATION'])
+	# check to make sure all bp types are present
+	for bp_type in ["++","+-","-+","--"]:
+		if bp_type not in sv_type_one_hot:
+			sv_type_one_hot[bp_type] = False
 	data_matrix.drop('BP_NOTATION', axis=1)
 	data_matrix = data_matrix.join(sv_type_one_hot)
 


### PR DESCRIPTION
The model expects all the BP_NOTATION types to be present after one-hot-encoding. If any BP_NOTATION was missing, this would return an error. Now all BP_NOTATIONS are checked to be present, if one is missing a new column is created and filled with "False"