### PR TITLE
v1.2.4 bugfix for savana run

### DIFF
--- a/savana/helper.py
+++ b/savana/helper.py
@@ -15,7 +15,7 @@ from time import time
 from datetime import datetime
 import argparse
 
-__version__ = "1.2.3"
+__version__ = "1.2.4"
 
 samflag_desc_to_number = {
 	"BAM_CMATCH": 0, # M

--- a/savana/savana.py
+++ b/savana/savana.py
@@ -45,8 +45,6 @@ def savana_run(args):
     # set number of threads to cpu count if none set
     if not args.threads:
         args.threads = cpu_count()
-    if not args.cna_threads:
-        args.cna_threads = cpu_count()
     # check if files are bam or cram (must have indices)
     if args.tumour.endswith('bam') and args.normal.endswith('bam'):
         args.is_cram = False


### PR DESCRIPTION
Removes the reference to undefined `cna_threads` argument when calling `savana run` (#50)