### PR TITLE
explicitly downgrade numpy to v 1.26 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cyvcf2==0.30.16
 scikit-learn==1.2.2
 pandas==2.0.0
 matplotlib==3.7.1
+numpy==1.26.4


### PR DESCRIPTION
Hi
For me cyvcf2 refuses to load when the Python packages are installed using requirements.txt. I think the reason is that it was built against a 1.x version of NumPy: numpy>=2 has a new ABI. I explicitly added numpy-1.26 to the requirements.txt to prevent installation of numpy-2.x.
Tested using python3.9 as specified in the documentation in a clean venv.
If you have time please test and merge if needed.
Thank you!